### PR TITLE
[Add] 네트워크 스크립트 작성

### DIFF
--- a/Assets/Scripts/Network.meta
+++ b/Assets/Scripts/Network.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bbf23936d95b7cf4589c62498be52e83
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Network/ByteArrayWrapper.cs
+++ b/Assets/Scripts/Network/ByteArrayWrapper.cs
@@ -1,0 +1,7 @@
+﻿public class ByteArrayWrapper
+{
+    public byte[] binaryData;
+
+    public ByteArrayWrapper() { }
+    public ByteArrayWrapper(byte[] data) => binaryData = data;
+}

--- a/Assets/Scripts/Network/ByteArrayWrapper.cs.meta
+++ b/Assets/Scripts/Network/ByteArrayWrapper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 93dde7573ebe8b54496a57967c423bb8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Network/InputMemoryStream.cs
+++ b/Assets/Scripts/Network/InputMemoryStream.cs
@@ -1,0 +1,131 @@
+﻿public class InputMemoryStream
+{
+    public byte[] buffer { get; private set; }
+    public int head { get; private set; }
+    private int capacity;
+    public int RemainingDataSize { get { return capacity - head; } }
+
+    public InputMemoryStream(byte[] buffer)
+    {
+        this.buffer = buffer;
+        head = 0;
+        capacity = buffer.Length;
+    }
+
+    #region Read
+        public void Read<T>(out T data) where T : struct
+        {
+            byte[] dataByte;
+            if (typeof(T) == typeof(bool))
+            {
+                dataByte = new byte[sizeof(bool)];
+                Array.Copy(buffer, head, dataByte, 0, sizeof(bool));
+                if (BitConverter.IsLittleEndian)
+                    Array.Reverse(dataByte);
+                data = (T)(object)BitConverter.ToBoolean(dataByte, 0);
+                head += sizeof(bool);
+            }
+            else if (typeof(T) == typeof(char))
+            {
+                dataByte = new byte[sizeof(char)];
+                Array.Copy(buffer, head, dataByte, 0, sizeof(char));
+                if (BitConverter.IsLittleEndian)
+                    Array.Reverse(dataByte);
+                data = (T)(object)BitConverter.ToChar(dataByte, 0);
+                head += sizeof(char);
+            }
+            else if (typeof(T) == typeof(byte))
+            {
+                data = (T)(object)buffer[head];
+                head += sizeof(byte);
+            }
+            else if (typeof(T) == typeof(sbyte))
+            {
+                data = (T)(object)buffer[head];
+                head += sizeof(sbyte);
+            }
+            else if (typeof(T) == typeof(short))
+            {
+                dataByte = new byte[sizeof(short)];
+                Array.Copy(buffer, head, dataByte, 0, sizeof(short));
+                if (BitConverter.IsLittleEndian)
+                    Array.Reverse(dataByte);
+                data = (T)(object)BitConverter.ToInt16(dataByte, 0);
+                head += sizeof(short);
+            }
+            else if (typeof(T) == typeof(ushort))
+            {
+                dataByte = new byte[sizeof(ushort)];
+                Array.Copy(buffer, head, dataByte, 0, sizeof(ushort));
+                if (BitConverter.IsLittleEndian)
+                    Array.Reverse(dataByte);
+                data = (T)(object)BitConverter.ToUInt16(dataByte, 0);
+                head += sizeof(ushort);
+            }
+            else if (typeof(T) == typeof(int))
+            {
+                dataByte = new byte[sizeof(int)];
+                Array.Copy(buffer, head, dataByte, 0, sizeof(int));
+                if (BitConverter.IsLittleEndian)
+                    Array.Reverse(dataByte);
+                data = (T)(object)BitConverter.ToInt32(dataByte, 0);
+                head += sizeof(int);
+            }
+            else if (typeof(T) == typeof(uint))
+            {
+                dataByte = new byte[sizeof(uint)];
+                Array.Copy(buffer, head, dataByte, 0, sizeof(uint));
+                if (BitConverter.IsLittleEndian)
+                    Array.Reverse(dataByte);
+                data = (T)(object)BitConverter.ToUInt32(dataByte, 0);
+                head += sizeof(uint);
+            }
+            else if (typeof(T) == typeof(long))
+            {
+                dataByte = new byte[sizeof(long)];
+                Array.Copy(buffer, head, dataByte, 0, sizeof(long));
+                if (BitConverter.IsLittleEndian)
+                    Array.Reverse(dataByte);
+                data = (T)(object)BitConverter.ToInt64(dataByte, 0);
+                head += sizeof(long);
+            }
+            else if (typeof(T) == typeof(ulong))
+            {
+                dataByte = new byte[sizeof(ulong)];
+                Array.Copy(buffer, head, dataByte, 0, sizeof(ulong));
+                if (BitConverter.IsLittleEndian)
+                    Array.Reverse(dataByte);
+                data = (T)(object)BitConverter.ToUInt64(dataByte, 0);
+                head += sizeof(ulong);
+            }
+            else if (typeof(T) == typeof(float))
+            {
+                dataByte = new byte[sizeof(float)];
+                Array.Copy(buffer, head, dataByte, 0, sizeof(float));
+                if (BitConverter.IsLittleEndian)
+                    Array.Reverse(dataByte);
+                data = (T)(object)BitConverter.ToSingle(dataByte, 0);
+                head += sizeof(float);
+            }
+            else if (typeof(T) == typeof(double))
+            {
+                dataByte = new byte[sizeof(double)];
+                Array.Copy(buffer, head, dataByte, 0, sizeof(double));
+                if (BitConverter.IsLittleEndian)
+                    Array.Reverse(dataByte);
+                data = (T)(object)BitConverter.ToDouble(dataByte, 0);
+                head += sizeof(double);
+            }
+            else
+                throw new ArgumentException("InputMemoryStream.Read parameter can be only primitive type except decimal");
+        }
+        public void Read(out string data)
+        {
+            Read(out int length);
+            char[] arr = new char[length];
+            for (int i = 0; i < length; i++)
+                Read(out arr[i]);
+            data = new string(arr);
+        }
+        #endregion
+}

--- a/Assets/Scripts/Network/InputMemoryStream.cs.meta
+++ b/Assets/Scripts/Network/InputMemoryStream.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1377a356e07d03d408598ed00d91b066
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Network/NetworkProtocol.cs
+++ b/Assets/Scripts/Network/NetworkProtocol.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+
+public class NetworkProtocol
+{
+    public static ByteArrayWrapper[] Receive(TcpClient client)
+    {
+        NetworkStream stream = client.GetStream();
+        var messages = new List<ByteArrayWrapper>();
+        while(stream.DataAvailable)
+        {
+            byte[] bufferLength = new byte[4];
+            stream.Read(bufferLength, 0, bufferLength.Length);
+            int msgSize = IPAddress.NetworkToHostOrder(BitConverter.ToInt32(bufferLength, 0));
+            byte[] readBuffer = new byte[msgSize];
+            stream.Read(readBuffer, 0, readBuffer.Length);
+            messages.Add(new ByteArrayWrapper(readBuffer));
+        }
+
+        return messages.ToArray();
+    }
+
+    public static void Send(TcpClient client, ByteArrayWrapper binaryData)
+    {
+        if (client == null) return;
+        NetworkStream stream = client.GetStream();
+        byte[] writeBuffer = binaryData.binaryData;
+        int msgSize = writeBuffer.Length;
+        byte[] bufferLegnth = BitConverter.GetBytes(IPAddress.HostToNetworkOrder(msgSize));
+        stream.Write(bufferLegnth, 0, bufferLegnth.Length);
+        stream.Write(writeBuffer, 0, msgSize);
+    }
+}

--- a/Assets/Scripts/Network/NetworkProtocol.cs.meta
+++ b/Assets/Scripts/Network/NetworkProtocol.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f0aff49479b6a014f93c96e1ad67e3e7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Network/OutputMemoryStream.cs
+++ b/Assets/Scripts/Network/OutputMemoryStream.cs
@@ -1,0 +1,60 @@
+﻿using System;
+
+public class OutputMemoryStream
+{
+    public byte[] buffer { get; private set; }
+    public int head { get; private set; }
+    private int capacity;
+
+    public OutputMemoryStream()
+    {
+        buffer = new byte[32];
+        head = 0;
+        capacity = 0;
+    }
+
+    #region Write
+        public void Write<T>(T data) where T : struct
+        {
+            byte[] dataBytes;
+            if (typeof(T) == typeof(bool)) dataBytes = BitConverter.GetBytes(Convert.ToBoolean(data));
+            else if (typeof(T) == typeof(char)) dataBytes = BitConverter.GetBytes(Convert.ToChar(data));
+            else if (typeof(T) == typeof(byte)) dataBytes = BitConverter.GetBytes(Convert.ToByte(data));
+            else if (typeof(T) == typeof(sbyte)) dataBytes = BitConverter.GetBytes(Convert.ToSByte(data));
+            else if (typeof(T) == typeof(short)) dataBytes = BitConverter.GetBytes(Convert.ToInt16(data));
+            else if (typeof(T) == typeof(ushort)) dataBytes = BitConverter.GetBytes(Convert.ToUInt16(data));
+            else if (typeof(T) == typeof(int)) dataBytes = BitConverter.GetBytes(Convert.ToInt32(data));
+            else if (typeof(T) == typeof(uint)) dataBytes = BitConverter.GetBytes(Convert.ToUInt32(data));
+            else if (typeof(T) == typeof(long)) dataBytes = BitConverter.GetBytes(Convert.ToInt64(data));
+            else if (typeof(T) == typeof(ulong)) dataBytes = BitConverter.GetBytes(Convert.ToUInt64(data));
+            else if (typeof(T) == typeof(float)) dataBytes = BitConverter.GetBytes(Convert.ToSingle(data));
+            else if (typeof(T) == typeof(double)) dataBytes = BitConverter.GetBytes(Convert.ToDouble(data));
+            else
+                throw new ArgumentException("OutputMemoryStream.Write parameter can be only primitive type except decimal");
+            if (BitConverter.IsLittleEndian)
+                Array.Reverse(dataBytes);
+
+            int resultHead = head + dataBytes.Length;
+            if (resultHead > capacity)
+            {
+                byte[] newBuffer = new byte[buffer.Length * 2];
+                buffer.CopyTo(newBuffer, 0);
+                buffer = newBuffer;
+                capacity = buffer.Length;
+            }
+
+            dataBytes.CopyTo(buffer, head);
+            head = resultHead;
+        }
+
+        public void Write(string data)
+        {
+            Write(data.Length);
+            foreach (var c in data)
+            {
+                Write(c);
+            }
+        }
+
+        #endregion
+}

--- a/Assets/Scripts/Network/OutputMemoryStream.cs.meta
+++ b/Assets/Scripts/Network/OutputMemoryStream.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bc355483c0d926d428882d63a618f2de
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Network/RequireType.cs
+++ b/Assets/Scripts/Network/RequireType.cs
@@ -1,0 +1,1 @@
+﻿public enum RequireType { Ready, SendData, Disconnect }

--- a/Assets/Scripts/Network/RequireType.cs.meta
+++ b/Assets/Scripts/Network/RequireType.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e7254e4adb261ad4abe016d63bd964bf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
클라이언트와 서버는 `byte[]`로 통신합니다.
배열의 처음에는 `RequireType`을 배치하여 데이터의 목적을 알도록 합니다.

* `ByteArrayWrapper`: 개발의 편의성을 위해서 만든 바이트 배열 클래스입니다.
* `NetworkProtocol`: `Send`, `Receive` 정적 메소드를 정의한 스크립트입니다.
* `InputMemoryStream`/`OutputMemoryStream`: 바이트 배열을 읽고 쓰도록 하는 클래스입니다. 보내려는 데이터는 `OutputMemoryStream`을, 받은 데이터는 `InputMemoryStream`을 이용합니다.
* `RequireType`: 보내려는 데이터의 목적을 명시합니다.